### PR TITLE
cmd/unity: add support for --update flag

### DIFF
--- a/cmd/unity/cmd/docker.go
+++ b/cmd/unity/cmd/docker.go
@@ -28,6 +28,7 @@ const (
 	flagDockerTesterRelPath flagName = "testerRelPath"
 	flagDockerCUEPath       flagName = "cuePath"
 	flagDockerVersion       flagName = "version"
+	flagDockerUpdate        flagName = "update"
 )
 
 // newTestCmd creates a new test command
@@ -46,6 +47,7 @@ func newDockerCmd(c *Command) *cobra.Command {
 	cmd.Flags().String(string(flagDockerTesterRelPath), "", "the relative path the module tester git root")
 	cmd.Flags().String(string(flagDockerCUEPath), "", "the path to the CUE binary to use")
 	cmd.Flags().String(string(flagDockerVersion), "", "the version being tested")
+	cmd.Flags().Bool(string(flagDockerUpdate), false, "update test archives when cmp fails")
 	return cmd
 }
 
@@ -59,6 +61,7 @@ func dockerDef(c *Command, args []string) error {
 			testerRelPath: flagDockerTesterRelPath.String(c),
 			cuePath:       flagDockerCUEPath.String(c),
 			version:       flagDockerVersion.String(c),
+			update:        flagDockerUpdate.Bool(c),
 		},
 	)
 }

--- a/cmd/unity/cmd/test.go
+++ b/cmd/unity/cmd/test.go
@@ -56,7 +56,7 @@ Need to document this command
 `,
 		RunE: mkRunE(c, testDef),
 	}
-	cmd.Flags().Bool(string(flagTestUpdate), false, "update files within tests when a cmp fails")
+	cmd.Flags().Bool(string(flagTestUpdate), false, "update files within test archives when cmp fails")
 	cmd.Flags().Bool(string(flagTestCorpus), false, "run tests for the submodules of the git repository that contains the working directory.")
 	cmd.Flags().String(string(flagTestRun), ".", "run only those tests matching the regular expression.")
 	cmd.Flags().StringP(string(flagTestDir), "d", ".", "search path for the project or corpus")
@@ -144,6 +144,7 @@ func testDef(c *Command, args []string) error {
 		runtime:         &r,
 		manifestDef:     manifestDef,
 		unsafe:          flagTestUnsafe.Bool(c),
+		update:          flagTestUpdate.Bool(c),
 	})
 	mt.verbose = flagTestVerbose.Bool(c)
 

--- a/cmd/unity/cmd/testdata/scripts/test_corpus_update.txt
+++ b/cmd/unity/cmd/testdata/scripts/test_corpus_update.txt
@@ -1,18 +1,7 @@
-# Verify that we can test a simple corpus setup
-#
-# The general setup here is that we create two projects, a and b (which are
-# identical, but for the directory path in which they are contained) Then have
-# a third directory, corpus, that adds a and b as submodules
+# Verify that --update works when using a corpus
 
 # Setup a
 cd a
-git init
-git add -A
-git commit -m 'Initial commit'
-cd $WORK
-
-# Setup b
-cd b
 git init
 git add -A
 git commit -m 'Initial commit'
@@ -22,18 +11,20 @@ cd $WORK
 cd corpus
 git init
 git submodule add $WORK/a a
-git submodule add $WORK/b b
 git add -A
 git commit -am 'Initial commit'
 cd $WORK
 
 # Test
 cd corpus
-unity test --corpus
+unity test --corpus --update
+! stdout .+
+cmp a/cue.mod/tests/basic.txt a/cue.mod/tests/basic.txt.golden
 
 -- corpus/README.md --
 -- a/.unquote --
 cue.mod/tests/basic.txt
+cue.mod/tests/basic.txt.golden
 -- a/cue.mod/module.cue --
 module: "mod.com"
 
@@ -43,6 +34,12 @@ package tests
 Versions: ["PATH"]
 
 -- a/cue.mod/tests/basic.txt --
+>cue eval
+>cmp stdout $WORK/eval.golden
+>
+>-- eval.golden --
+>x: 4
+-- a/cue.mod/tests/basic.txt.golden --
 >cue eval
 >cmp stdout $WORK/eval.golden
 >

--- a/cmd/unity/cmd/testdata/scripts/test_project_update.txt
+++ b/cmd/unity/cmd/testdata/scripts/test_project_update.txt
@@ -1,0 +1,39 @@
+# Verify that passing --update works with a simple project
+
+# Initial setup
+git init
+git add -A
+git commit -m 'Initial commit'
+
+# Test
+unity test --update
+! stdout .+
+cmp cue.mod/tests/basic.txt cue.mod/tests/basic.txt.golden
+
+-- .unquote --
+cue.mod/tests/basic.txt
+cue.mod/tests/basic.txt.golden
+-- cue.mod/module.cue --
+module: "mod.com"
+
+-- cue.mod/tests/tests.cue --
+package tests
+
+Versions: ["PATH"]
+
+-- cue.mod/tests/basic.txt --
+>cue eval
+>cmp stdout $WORK/eval.golden
+>
+>-- eval.golden --
+>x: 4
+-- cue.mod/tests/basic.txt.golden --
+>cue eval
+>cmp stdout $WORK/eval.golden
+>
+>-- eval.golden --
+>x: 5
+-- x.cue --
+package x
+
+x: 5

--- a/cmd/unity/cmd/testdata/scripts/test_project_update_overlay.txt
+++ b/cmd/unity/cmd/testdata/scripts/test_project_update_overlay.txt
@@ -1,0 +1,38 @@
+# Verify the --update works when using an overlay
+
+# Initial setup
+git init
+git add -A
+git commit -m 'Initial commit'
+
+# Test
+unity test --overlay overlay --update
+! stdout .+
+cmp overlay/basic.txt overlay/basic.txt.golden
+
+-- .unquote --
+overlay/basic.txt
+overlay/basic.txt.golden
+-- cue.mod/module.cue --
+module: "mod.com"
+
+-- overlay/tests.cue --
+package tests
+
+Versions: ["PATH"]
+-- overlay/basic.txt --
+>cue eval
+>cmp stdout $WORK/eval.golden
+>
+>-- eval.golden --
+>x: 4
+-- overlay/basic.txt.golden --
+>cue eval
+>cmp stdout $WORK/eval.golden
+>
+>-- eval.golden --
+>x: 5
+-- x.cue --
+package x
+
+x: 5


### PR DESCRIPTION
This allows test archives to be updated when cmp commands fail and the
reference file is within the test archive.