### PR TITLE
ci: only build branch pushes for main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,12 @@ name: Test
 on:
   push:
     branches:
-    - '**'
-    tags-ignore:
+    - main
+    tags:
     - v*
+  pull_request:
+    branches:
+    - '**'
 jobs:
   test:
     strategy:

--- a/internal/ci/workflows.cue
+++ b/internal/ci/workflows.cue
@@ -36,9 +36,10 @@ test: _#bashWorkflow & {
 	name: "Test"
 	on: {
 		push: {
-			branches: ["**"] // any branch (including '/' namespaced branches)
-			"tags-ignore": [_#releaseTagPattern]
+			branches: ["main"]
+			tags: [_#releaseTagPattern]
 		}
+		pull_request: branches: ["**"]
 	}
 
 	jobs: {


### PR DESCRIPTION
Also build PRs and tags of releases. Prevents builds from starting for
branches we simply push up (which is annoying)