### PR TITLE
cmd/unity: support --staged and --ignore-dirty

### DIFF
--- a/cmd/unity/cmd/script_test.go
+++ b/cmd/unity/cmd/script_test.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	homeDirName = ".user-home"
+	tmpDirName  = ".tmp-dir"
 )
 
 func TestMain(m *testing.M) {
@@ -78,6 +79,11 @@ func TestScripts(t *testing.T) {
 						return err
 					}
 
+					tmp := filepath.Join(e.WorkDir, tmpDirName)
+					if err := os.Mkdir(tmp, 0777); err != nil {
+						return err
+					}
+
 					// Add GOBIN (set above) to PATH
 					var path string
 					for i := len(e.Vars) - 1; i >= 0; i-- {
@@ -94,6 +100,7 @@ func TestScripts(t *testing.T) {
 						"UNITY_TEST_PATH_TO_SELF="+selfDir,
 						"PATH="+path,
 						"HOME="+home,
+						"TMPDIR="+tmp,
 						"UNITY_SEMVER_URL_TEMPLATE=file://"+filepath.Join(cwd, "testdata", "archives", "{{.Artefact}}"),
 					)
 					if v == "unsafe" {
@@ -108,6 +115,7 @@ func TestScripts(t *testing.T) {
 					h.git("config", "--global", "user.email", "unity@cuelang.org")
 					h.write(filepath.Join(home, ".gitignore"), strings.Join([]string{
 						homeDirName,
+						tmpDirName,
 					}, "\n"))
 					h.git("config", "--global", "core.excludesfile", filepath.Join(home, ".gitignore"))
 					h.git("config", "--global", "init.defaultBranch", "main")

--- a/cmd/unity/cmd/test.go
+++ b/cmd/unity/cmd/test.go
@@ -28,14 +28,16 @@ import (
 )
 
 const (
-	flagTestUpdate  flagName = "update"
-	flagTestCorpus  flagName = "corpus"
-	flagTestRun     flagName = "run"
-	flagTestDir     flagName = "dir"
-	flagTestVerbose flagName = "verbose"
-	flagTestNoPath  flagName = "nopath"
-	flagTestOverlay flagName = "overlay"
-	flagTestUnsafe  flagName = "unsafe"
+	flagTestUpdate      flagName = "update"
+	flagTestCorpus      flagName = "corpus"
+	flagTestRun         flagName = "run"
+	flagTestDir         flagName = "dir"
+	flagTestVerbose     flagName = "verbose"
+	flagTestNoPath      flagName = "nopath"
+	flagTestOverlay     flagName = "overlay"
+	flagTestUnsafe      flagName = "unsafe"
+	flagTestStaged      flagName = "staged"
+	flagTestIgnoreDirty flagName = "ignore-dirty"
 
 	// dockerImage is the image we use when running in safe mode
 	//
@@ -64,6 +66,8 @@ Need to document this command
 	cmd.Flags().Bool(string(flagTestNoPath), false, "do not allow CUE version PATH. Useful for CI")
 	cmd.Flags().String(string(flagTestOverlay), "", "the directory from which to source overlays")
 	cmd.Flags().Bool(string(flagTestUnsafe), os.Getenv("UNITY_UNSAFE") != "", "do not use Docker for executing scripts")
+	cmd.Flags().Bool(string(flagTestStaged), false, "apply staged changes during tests")
+	cmd.Flags().Bool(string(flagTestIgnoreDirty), false, "ignore untracked files, and staged files unless --staged")
 	return cmd
 }
 
@@ -145,6 +149,8 @@ func testDef(c *Command, args []string) error {
 		manifestDef:     manifestDef,
 		unsafe:          flagTestUnsafe.Bool(c),
 		update:          flagTestUpdate.Bool(c),
+		staged:          flagTestStaged.Bool(c),
+		ignoreDirty:     flagTestIgnoreDirty.Bool(c),
 	})
 	mt.verbose = flagTestVerbose.Bool(c)
 

--- a/cmd/unity/cmd/testdata/scripts/test_project_staged_ignore_dirty.txt
+++ b/cmd/unity/cmd/testdata/scripts/test_project_staged_ignore_dirty.txt
@@ -1,0 +1,76 @@
+# Verify that we get a sensible error message when we have either untracked or
+# staged files in the working tree and we have not provided --staged. Verify
+# that error message disappears when we provide --ignore-dirty, and also that
+# --staged behaves as expected.
+
+# Initial setup. Careful additions
+git init
+git add x.cue
+git commit -m 'Initial commit'
+
+# Untracked only
+! unity test
+stderr 'working tree has untracked files; stage changes and use --staged or use --ignore-dirty'
+
+# Ignore untracked only
+unity test --ignore-dirty
+ ! stdout .+
+
+# Stage some changes
+git add cue.mod/module.cue
+
+# Untracked and staged changes
+! unity test
+stderr 'working tree has untracked files; stage changes and use --staged or use --ignore-dirty'
+
+# Try to use only staged changes
+! unity test --staged
+stderr 'working tree has untracked files; stage changes and use --staged or use --ignore-dirty'
+
+# Ignore untracked and staged changes
+unity test --ignore-dirty
+ ! stdout .+
+
+# Stage everything
+git add -A
+
+# Staged changes
+! unity test
+stderr 'working tree has staged changes; use --staged to test with staged changes'
+
+# Actually use staged changes
+exec echo $WORK/cue.mod/tests
+unity test --staged
+! stdout .+
+
+# Ignore staged changes
+unity test --ignore-dirty
+! stdout .+
+
+-- .unquote --
+cue.mod/tests/basic1.txt
+cue.mod/tests/basic2.txt
+-- cue.mod/module.cue --
+module: "mod.com"
+
+-- cue.mod/tests/tests.cue --
+package tests
+
+Versions: ["PATH"]
+
+-- cue.mod/tests/basic1.txt --
+>cue eval
+>cmp stdout $WORK/eval.golden
+>
+>-- eval.golden --
+>x: 5
+-- cue.mod/tests/basic2.txt --
+>cue eval
+>cmp stdout $WORK/eval.golden
+>
+>-- eval.golden --
+>x: 5
+-- x.cue --
+package x
+
+x: 5

--- a/cmd/unity/cmd/util.go
+++ b/cmd/unity/cmd/util.go
@@ -25,10 +25,6 @@ import (
 	"github.com/rogpeppe/go-internal/testscript"
 )
 
-func git(args ...string) (string, error) {
-	return gitDir(".", args...)
-}
-
 func gitDir(dir string, args ...string) (string, error) {
 	return gitEnvDir(os.Environ(), dir, args...)
 }


### PR DESCRIPTION
Flag --staged will use staged changes from any projects. Separately,
--ignore-dirty will ignore any non-porcelain project status.