### PR TITLE
cmd/unity: gerrit ref version resolver

### DIFF
--- a/cmd/unity/cmd/buildhelper.go
+++ b/cmd/unity/cmd/buildhelper.go
@@ -30,6 +30,15 @@ import (
 	"golang.org/x/mod/semver"
 )
 
+const (
+	// clonesDir is the subdirectory within the user cache dir in which various
+	// project clones are maintained
+	clonesDir = "clones"
+
+	// cloneLockfile is the filname suffix given to lock files of clones.
+	cloneLockfile = ".lock"
+)
+
 type buildHelper struct {
 	// userCacheDir is the directory within which we can create subdirectories
 	// that cache unity-related artefacts
@@ -67,6 +76,23 @@ func newBuildHelper() (*buildHelper, error) {
 		targetGOARCH: runtime.GOARCH,
 	}
 	return res, nil
+}
+
+// cueCloneDir returns the path at which, within the user cache dir, the clone
+// of CUE is maintained.
+func (bh *buildHelper) cueCloneDir() string {
+	return filepath.Join(bh.userCacheDir, clonesDir, "cue")
+}
+
+// cueVersionHash is called by various resolvers to create a hash
+// based on a version. The various callers are responsible for
+// ensuring that version does/doesn't clash when expected
+func (bh *buildHelper) cueVersionHash(version string) *cache.Hash {
+	h := cache.NewHash("cue version")
+	h.Write([]byte("GOOS: " + bh.targetGOOS))
+	h.Write([]byte("GOARCH: " + bh.targetGOARCH))
+	h.Write([]byte(version))
+	return h
 }
 
 // targetDocker updates bh to target the supplied docker image. The docker

--- a/cmd/unity/cmd/gerritrefresolver.go
+++ b/cmd/unity/cmd/gerritrefresolver.go
@@ -1,0 +1,113 @@
+// Copyright 2021 The CUE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/rogpeppe/go-internal/lockedfile"
+)
+
+const (
+	cueGitSource = "https://cue.googlesource.com/cue"
+)
+
+type gerritRefResolver struct {
+	config resolverConfig
+
+	// dir is the directory within which the CUE clone exists
+	dir string
+
+	// lock controls access to the user cache dir clone of CUE
+	lock *lockedfile.Mutex
+}
+
+func newGerritRefResolver(c resolverConfig) (resolver, error) {
+	dir := c.bh.cueCloneDir()
+	if err := os.MkdirAll(dir, 0777); err != nil {
+		return nil, fmt.Errorf("failed to mkdir %s: %v", dir, err)
+	}
+	res := &gerritRefResolver{
+		config: c,
+		dir:    dir,
+		lock:   lockedfile.MutexAt(dir + cloneLockfile),
+	}
+	return res, nil
+}
+
+func (g *gerritRefResolver) resolve(version, _, _, targetDir string) error {
+	if !strings.HasPrefix(version, "refs/changes/") {
+		return errNoMatch
+	}
+
+	target := filepath.Join(targetDir, "cue")
+
+	// Check whether we have a cache hit
+	h := g.config.bh.cueVersionHash(version)
+	key := h.Sum()
+	ce, _, err := g.config.bh.cache.GetFile(key)
+	if err == nil {
+		return copyExecutableFile(ce, target)
+	}
+
+	// We need to build
+	unlock, err := g.lock.Lock()
+	if err != nil {
+		return fmt.Errorf("failed to acquire lockfile: %v", err)
+	}
+	defer unlock()
+
+	// Ensure we have a clone in the first place
+	if _, err := os.Stat(filepath.Join(g.dir, ".git")); err != nil {
+		if _, err := gitDir(g.dir, "clone", cueGitSource, "."); err != nil {
+			return fmt.Errorf("failed to clone CUE: %v", err)
+		}
+	}
+
+	// fetch the version
+	if _, err := gitDir(g.dir, "fetch", cueGitSource, version); err != nil {
+		return fmt.Errorf("failed to fetch %s: %v", version, err)
+	}
+
+	// move to FETCH_HEAD
+	if _, err := gitDir(g.dir, "checkout", "FETCH_HEAD"); err != nil {
+		return fmt.Errorf("failed to checkout FETCH_HEAD: %v", err)
+	}
+
+	// build
+	buildDir := filepath.Join(g.dir, "cmd", "cue")
+	cmd := exec.Command("go", "build")
+	cmd.Dir = buildDir
+	cmd.Env = append(os.Environ(), g.config.bh.buildEnv()...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run [%v] in %s: %v\n%s", cmd, buildDir, err, out)
+	}
+	buildTarget := filepath.Join(buildDir, "cue")
+
+	f, err := os.Open(buildTarget)
+	if err != nil {
+		return fmt.Errorf("failed to open build result %s: %v", buildTarget, err)
+	}
+	if _, _, err := g.config.bh.cache.Put(key, f); err != nil {
+		return fmt.Errorf("failed to write cue to the cache: %v", err)
+	}
+
+	return copyExecutableFile(buildTarget, target)
+}

--- a/cmd/unity/cmd/script_test.go
+++ b/cmd/unity/cmd/script_test.go
@@ -15,9 +15,11 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -62,6 +64,19 @@ func TestScripts(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	var env struct {
+		GOCACHE    string
+		GOMODCACHE string
+	}
+	goenv := exec.Command("go", "env", "-json")
+	out, err := goenv.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(out, &env); err != nil {
+		t.Fatal(err)
+	}
+
 	for _, v := range []string{"safe", "unsafe"} {
 		v := v
 		t.Run(v, func(t *testing.T) {
@@ -95,6 +110,8 @@ func TestScripts(t *testing.T) {
 
 					// Augment the environment
 					e.Vars = append(e.Vars,
+						"GOCACHE="+env.GOCACHE,
+						"GOMODCACHE="+env.GOMODCACHE,
 						"PATH="+path,
 						homeEnvName()+"="+home,
 						tempEnvName()+"="+tmp,

--- a/cmd/unity/cmd/semverresolver.go
+++ b/cmd/unity/cmd/semverresolver.go
@@ -1,3 +1,17 @@
+// Copyright 2021 The CUE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (
@@ -15,7 +29,6 @@ import (
 	"text/template"
 
 	"cuelang.org/go/cue/errors"
-	"github.com/rogpeppe/go-internal/cache"
 	"golang.org/x/mod/semver"
 )
 
@@ -95,19 +108,11 @@ func (sr *semverResolver) buildURL(version string, artefact string) (*url.URL, e
 	return u, nil
 }
 
-func (sr *semverResolver) buildHash(version string) *cache.Hash {
-	h := cache.NewHash("cue semver version")
-	h.Write([]byte("GOOS: " + sr.config.bh.targetGOOS))
-	h.Write([]byte("GOARCH: " + sr.config.bh.targetGOARCH))
-	h.Write([]byte(version))
-	return h
-}
-
 func (sr *semverResolver) resolve(version, dir, working, targetDir string) error {
 	if !semver.IsValid(version) {
 		return errNoMatch
 	}
-	h := sr.buildHash(version)
+	h := sr.config.bh.cueVersionHash(version)
 	key := h.Sum()
 	ce, _, err := sr.config.bh.cache.GetFile(key)
 	if err == nil {

--- a/cmd/unity/cmd/testdata/scripts/test_project_gerrit_ref.txt
+++ b/cmd/unity/cmd/testdata/scripts/test_project_gerrit_ref.txt
@@ -1,0 +1,34 @@
+# Verify that we can resolve a CUE version that is a Gerrit ref
+
+[!long] skip 'We clone the actual CUE repo here so this is a long test'
+
+# Initial setup
+git init
+git add -A
+git commit -m 'Initial commit'
+
+# Test - ref corresponds to the same commit as v0.3.0-beta.5
+unity test refs/changes/07/8707/3
+! stdout .+
+
+-- .unquote --
+cue.mod/tests/basic.txt
+-- .gitignore --
+/_cue
+-- cue.mod/module.cue --
+module: "mod.com"
+
+-- cue.mod/tests/tests.cue --
+package tests
+
+Versions: ["PATH"]
+-- cue.mod/tests/basic.txt --
+>cue eval
+>cmp stdout $WORK/eval.golden
+>
+>-- eval.golden --
+>x: 5
+-- x.cue --
+package x
+
+x: 5

--- a/cmd/unity/cmd/versions.go
+++ b/cmd/unity/cmd/versions.go
@@ -42,6 +42,7 @@ func newVersionResolver(c resolverConfig) (*versionResolver, error) {
 		newPathResolver,
 		newSemverResolver,
 		newAbsolutePathResolver,
+		newGerritRefResolver,
 	}
 	var resolvers []resolver
 	for i, rb := range inits {


### PR DESCRIPTION
Will ultimately be used in the cueckoo command to trigger tests against
CLs.