### PR TITLE
cmd/unity: fix bug in git status calculation

### DIFF
--- a/cmd/unity/cmd/project.go
+++ b/cmd/unity/cmd/project.go
@@ -320,9 +320,10 @@ func (mt *moduleTester) verifyGitStatus(dir string) (hasStaged bool, err error) 
 	lines := strings.Split(status, "\n")
 	hasUntracked := false
 	for _, l := range lines {
-		if strings.HasPrefix(l, "??") {
+		switch {
+		case strings.HasPrefix(l, "??"):
 			hasUntracked = true
-		} else {
+		case l[0] != ' ':
 			hasStaged = true
 		}
 	}
@@ -416,7 +417,7 @@ func (mt *moduleTester) run(m *module, log *bytes.Buffer, version string) (err e
 	if _, err = gitDir(m.gitRoot, "worktree", "add", "--detach", td); err != nil {
 		return fmt.Errorf("failed to create copy of current HEAD from %s: %v", m.gitRoot, err)
 	}
-	if m.hasStaged {
+	if m.hasStaged && mt.staged {
 		// TODO make this more efficient by not reading into memory
 		var changes, stderr bytes.Buffer
 		read := exec.Command("git", "diff", "--staged")

--- a/cmd/unity/cmd/testdata/scripts/test_project_staged_ignore_dirty.txt
+++ b/cmd/unity/cmd/testdata/scripts/test_project_staged_ignore_dirty.txt
@@ -16,6 +16,18 @@ stderr 'working tree has untracked files; stage changes and use --staged or use 
 unity test --ignore-dirty
  ! stdout .+
 
+# Make a modification
+cp x.cue.new x.cue
+
+# Untracked only and modified
+! unity test
+stderr 'working tree has untracked files; stage changes and use --staged or use --ignore-dirty'
+
+# Ignore untracked only
+exec git status
+unity test --ignore-dirty
+ ! stdout .+
+
 # Stage some changes
 git add cue.mod/module.cue
 
@@ -73,4 +85,9 @@ Versions: ["PATH"]
 -- x.cue --
 package x
 
+x: 5
+-- x.cue.new --
+package x
+
+// A comment
 x: 5


### PR DESCRIPTION
We were also unconidtionally trying to apply staged changes when we
hadn't asked for them, based only on an incorrect determination as to
whether there were any.