### PR TITLE
projects: add dummy go.mod

### DIFF
--- a/projects/go.mod
+++ b/projects/go.mod
@@ -1,0 +1,3 @@
+module github.com/cue-sh/unity/projects
+
+go 1.17


### PR DESCRIPTION
This prevents a go mod tidy (or equivalent) in the root of unity
traversing into all of the projects that are linked as submodules. If
they were Go modules themselves that wouldn't be a problem, but we're
not guaranteed of that. Hence without this dummy module we could end up
traversing many thousands of directories/files.