### PR TITLE
projects: use testscript comment sections to reduce noisy output

### DIFF
--- a/overlays/projects/github.com/TangoGroup/cfn-cue/eval.txt
+++ b/overlays/projects/github.com/TangoGroup/cfn-cue/eval.txt
@@ -1,4 +1,7 @@
+# eval
 cue eval test0.cue
+
+# Compare vs golden files
 cmp stdout $WORK/stdout.golden
 
 -- stdout.golden --


### PR DESCRIPTION
When running cue eval (which defaults to stdout) the output can be very
long. One option is to have this output be directed to a file. This is
somewhat less than ideal because it makes debugging that bit harder.

Other option is to use testscript comment blocks to hide that output.

testscript determines sections of commands to be a comment followed by
contiguous lines of commands, e.g.

    # This is a comment
    exec ls

    # Another comment
    cmp stdout stdout.golden

Here there are two sections. If all of these commands in a section
succeed according to their specification (in this case all must exit
with a zero exit code) then the log output of testscript in that section
will be collapsed. Hence it the exec ls command succeeds, then
regardless of the result of the cmp command, the output from the exec ls
section will be collapsed, and only the comment "header" for that
section will be logged.