### PR TITLE
cmd/unity: log results as a table

### DIFF
--- a/cmd/unity/cmd/corpus.go
+++ b/cmd/unity/cmd/corpus.go
@@ -22,14 +22,6 @@ import (
 )
 
 func testCorpus(cmd *Command, mt *moduleTester, versions []string) error {
-	mt.logger = func(m *module, version string) error {
-		rel, err := filepath.Rel(mt.cwd, m.root)
-		if err != nil {
-			return fmt.Errorf("failed to determine %s relative to %s: %v", m.root, mt.cwd, err)
-		}
-		fmt.Fprintf(os.Stderr, "testing %s against version %s\n", rel, version)
-		return nil
-	}
 	submodConfig := filepath.Join(mt.gitRoot, ".gitmodules")
 	if _, err := os.Stat(submodConfig); err != nil {
 		return fmt.Errorf("failed to find git submodules config file at %s: %v", submodConfig, err)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	cuelang.org/go v0.3.0-beta.5.0.20210217105737-430c3ddf5331
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/rogpeppe/go-internal v1.7.1-0.20210301144926-2630b2f15b04
 	github.com/spf13/cobra v1.0.0
 	golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+
 github.com/lib/pq v1.0.0 h1:X5PMW56eZitiTeO7tKzZxFCSpbFZJtkMMooicw2us9A=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -77,6 +79,8 @@ github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de h1:D5x39vF5KCwKQaw+OC9
 github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de/go.mod h1:kJun4WP5gFuHZgRjZUWWuH1DTxCtxbHDOIJsudS8jzY=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e h1:aoZm08cpOy4WuID//EZDgcC4zIxODThtZNPirFr42+A=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=


### PR DESCRIPTION
In either --corpus or project mode it is good to see the time it took
for each entry of the test matrix. Log that.

The first entry in a module's manifest's version list is used as the
base version. All subsequent tests of that module against different
version have their timings printed relative (as a % difference) to that
base version.