### PR TITLE
cmd/unity: debug print resolved versions

### DIFF
--- a/cmd/unity/cmd/absolutepathresolver.go
+++ b/cmd/unity/cmd/absolutepathresolver.go
@@ -39,9 +39,9 @@ func newAbsolutePathResolver(c resolverConfig) (resolver, error) {
 	return res, nil
 }
 
-func (a *absolutePathResolver) resolve(version, dir, workingDir, target string) error {
+func (a *absolutePathResolver) resolve(version, dir, workingDir, target string) (string, error) {
 	if !filepath.IsAbs(version) {
-		return errNoMatch
+		return "", errNoMatch
 	}
 	return a.cp.resolve(version, target)
 }

--- a/cmd/unity/cmd/commitresolver.go
+++ b/cmd/unity/cmd/commitresolver.go
@@ -37,9 +37,9 @@ func newCommitResolver(c resolverConfig) (resolver, error) {
 	return res, nil
 }
 
-func (g *commitResolver) resolve(version, _, _, target string) error {
+func (g *commitResolver) resolve(version, _, _, target string) (string, error) {
 	if !strings.HasPrefix(version, commitVersionPrefix) {
-		return errNoMatch
+		return "", errNoMatch
 	}
 	version = strings.TrimPrefix(version, commitVersionPrefix)
 	return g.cc.resolve(version, target, func(c *commonCUEResolver) (string, error) {
@@ -55,6 +55,7 @@ func (g *commitResolver) resolve(version, _, _, target string) error {
 		if err != nil {
 			return "", fmt.Errorf("failed to rev-parse HEAD: %v", err)
 		}
+		version = strings.TrimSpace(version)
 		return version, nil
 	})
 }

--- a/cmd/unity/cmd/gerritrefresolver.go
+++ b/cmd/unity/cmd/gerritrefresolver.go
@@ -33,9 +33,9 @@ func newGerritRefResolver(c resolverConfig) (resolver, error) {
 	return res, nil
 }
 
-func (g *gerritRefResolver) resolve(version, _, _, target string) error {
+func (g *gerritRefResolver) resolve(version, _, _, target string) (string, error) {
 	if !strings.HasPrefix(version, "refs/changes/") {
-		return errNoMatch
+		return "", errNoMatch
 	}
 	return g.cc.resolve(version, target, func(c *commonCUEResolver) (string, error) {
 		// fetch the version

--- a/cmd/unity/cmd/gomodresolver.go
+++ b/cmd/unity/cmd/gomodresolver.go
@@ -14,6 +14,8 @@
 
 package cmd
 
+import "fmt"
+
 // goModResolver resolves a CUE version of "go.mod" and uses the Go module
 // context within which the CUE module is found to resolve a CUE version. cue
 // is then built within a .unity-bin directory at the Go module root
@@ -28,9 +30,13 @@ func newGoModResolver(c resolverConfig) (resolver, error) {
 	return res, nil
 }
 
-func (a *goModResolver) resolve(version, dir, workingDir, target string) error {
+func (a *goModResolver) resolve(version, dir, workingDir, target string) (string, error) {
 	if version != "go.mod" {
-		return errNoMatch
+		return "", errNoMatch
 	}
-	return a.cp.resolve(dir, target)
+	commit, err := a.cp.resolve(dir, target)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s (%s)", version, commit), nil
 }

--- a/cmd/unity/cmd/main.go
+++ b/cmd/unity/cmd/main.go
@@ -24,6 +24,13 @@ import (
 )
 
 const (
+	// cueModule is the path used to identify the module that contains
+	// cmd/cue
+	cueModule = "cuelang.org/go"
+
+	// cmdCue is the import path to cmd/cue
+	cmdCue = cueModule + "/cmd/cue"
+
 	// moduleSelf is used to identify build info for the running unity
 	// process
 	moduleSelf = "github.com/cue-sh/unity"

--- a/cmd/unity/cmd/pathresolver.go
+++ b/cmd/unity/cmd/pathresolver.go
@@ -34,17 +34,19 @@ func newPathResolver(c resolverConfig) (resolver, error) {
 	return res, nil
 }
 
-func (p *pathResolver) resolve(version, dir, workingDir, target string) error {
+func (p *pathResolver) resolve(version, dir, workingDir, target string) (string, error) {
 	if version != "PATH" {
-		return errNoMatch
+		return "", errNoMatch
 	}
 	if !p.config.allowPATH {
-		return errPATHNotAllowed
+		return "", errPATHNotAllowed
 	}
 	exe, err := exec.LookPath("cue")
 	if err != nil {
-		return fmt.Errorf("failed to find cue in PATH: %v", err)
+		return "", fmt.Errorf("failed to find cue in PATH: %v", err)
 	}
 	// TODO: check GOOS and GOARCH for the result
-	return copyExecutableFile(exe, target)
+	// TODO: extract more useful version information from the cue binary
+	// in PATH
+	return "PATH", copyExecutableFile(exe, target)
 }

--- a/cmd/unity/cmd/project.go
+++ b/cmd/unity/cmd/project.go
@@ -485,16 +485,17 @@ type module struct {
 func (mt *moduleTester) run(tr *testResult) (err error) {
 	m := tr.module
 	version := tr.version
-	fmt.Fprintf(os.Stderr, "testing %s against version %s\n", tr.module.path, version)
 	// TODO: we really shouldn't need to be resolving this again
 	working, err := mt.tempDir("run-dir")
 	if err != nil {
 		return fmt.Errorf("failed to create temp directory for run: %v", err)
 	}
 	cuePath := filepath.Join(working, "cue")
-	if err := m.tester.versionResolver.resolve(version, m.root, working, cuePath); err != nil {
+	tr.resolvedVersion, err = m.tester.versionResolver.resolve(version, m.root, working, cuePath)
+	if err != nil {
 		return err
 	}
+	fmt.Fprintf(os.Stderr, "testing %s against version %s\n", tr.module.path, tr.resolvedVersion)
 	// Create a pristine copy of the git root with no history
 	td, err := mt.tempDir("workdir")
 	if err != nil {

--- a/cmd/unity/cmd/script_test.go
+++ b/cmd/unity/cmd/script_test.go
@@ -60,7 +60,7 @@ func TestScripts(t *testing.T) {
 	cueTarget := filepath.Join(selfDir, "cue")
 	// install the required version of CUE to ensure that CUE versions of PATH
 	// specified in unity tests run consistently for the target docker image
-	if err := bh.buildAndCache(cwd, cueTarget, "cuelang.org/go/cmd/cue"); err != nil {
+	if err := bh.buildAndCache(cwd, cueTarget, cmdCue); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/unity/cmd/testdata/scripts/test_project_absolute_path_resolver.txt
+++ b/cmd/unity/cmd/testdata/scripts/test_project_absolute_path_resolver.txt
@@ -13,6 +13,7 @@ git commit -m 'Initial commit'
 # Test
 unity test $WORK/_cue
 ! stdout .+
+stderr 'ok.*mod\.com.*bcd752ada5ab3e5814f7b95e5f82af61b5f4cf3e'
 
 -- .unquote --
 cue.mod/tests/basic.txt

--- a/cmd/unity/cmd/testdata/scripts/test_project_commit_resolver.txt
+++ b/cmd/unity/cmd/testdata/scripts/test_project_commit_resolver.txt
@@ -8,8 +8,9 @@ git add -A
 git commit -m 'Initial commit'
 
 # Test - corresponds to the version that is v0.3.0-beta.5
-unity test commit:bcd752ada5ab3e5814f7b95e5f82af61b5f4cf3e
+unity test commit:bcd752ad
 ! stdout .+
+stderr 'ok.*mod\.com.*bcd752ada5ab3e5814f7b95e5f82af61b5f4cf3e'
 
 -- .unquote --
 cue.mod/tests/basic.txt

--- a/cmd/unity/cmd/testdata/scripts/test_project_gerrit_ref_resolver.txt
+++ b/cmd/unity/cmd/testdata/scripts/test_project_gerrit_ref_resolver.txt
@@ -10,6 +10,7 @@ git commit -m 'Initial commit'
 # Test - ref corresponds to the same commit as v0.3.0-beta.5
 unity test refs/changes/07/8707/3
 ! stdout .+
+stderr 'ok.*mod\.com.*refs/changes/07/8707/3'
 
 -- .unquote --
 cue.mod/tests/basic.txt

--- a/cmd/unity/cmd/testdata/scripts/test_project_go.mod_resolver.txt
+++ b/cmd/unity/cmd/testdata/scripts/test_project_go.mod_resolver.txt
@@ -11,6 +11,7 @@ git commit -m 'Initial commit'
 # Test
 unity test go.mod
 ! stdout .+
+stderr 'ok.*mod\.com.*go\.mod.*\(v0\.3\.0-beta\.5\)'
 
 -- .unquote --
 cue.mod/tests/basic.txt

--- a/cmd/unity/cmd/testdata/scripts/test_project_simple_real_version.txt
+++ b/cmd/unity/cmd/testdata/scripts/test_project_simple_real_version.txt
@@ -14,6 +14,7 @@ git commit -m 'Initial commit'
 # Test
 unity test
 ! stdout .+
+stderr 'ok.*mod\.com.*v0\.3\.0-beta\.5'
 
 -- .unquote --
 cue.mod/tests/basic1.txt


### PR DESCRIPTION
This allows us to see what versions/commits were actually tested in the
case of go.mod and absolute path versions.