### PR TITLE
projects: set baseline version of vector to v0.3.0-beta.6

### DIFF
--- a/overlays/projects/github.com/timberio/vector/tests.cue
+++ b/overlays/projects/github.com/timberio/vector/tests.cue
@@ -1,3 +1,3 @@
 package tests
 
-Versions: ["v0.3.0-beta.5"]
+Versions: ["v0.3.0-beta.6"]


### PR DESCRIPTION
1589a074 fixed a bug related to comparing to bottom. This revealed that
previous evaluations of the vector configuration were in fact incorrect.
Hence move the base version up to v0.3.0-beta.6 which includes this
change.