### PR TITLE
cmd/unity: do not recurse into cue.mod when searching for modules

### DIFF
--- a/cmd/unity/cmd/project.go
+++ b/cmd/unity/cmd/project.go
@@ -436,7 +436,9 @@ func (mt *moduleTester) deriveModules(dir string) (modules []*module, err error)
 			return fmt.Errorf("failed to create module instance at %s: %v", modDir, err)
 		}
 		modules = append(modules, m)
-		return nil
+		// Do not recurse within the cue.mod - otherwise we might find modules
+		// in the vendor
+		return filepath.SkipDir
 	})
 	return
 }

--- a/cmd/unity/cmd/testdata/scripts/test_project_simple.txt
+++ b/cmd/unity/cmd/testdata/scripts/test_project_simple.txt
@@ -17,6 +17,12 @@ stdout 'PASS'
 -- .unquote --
 cue.mod/tests/basic1.txt
 cue.mod/tests/basic2.txt
+-- cue.mod/pkg/acme.com/other/other.cue --
+package other
+
+y: 5
+-- cue.mod/pkg/acme.com/other/cue.mod/module.cue --
+module: "acme.com/other"
 -- cue.mod/module.cue --
 module: "mod.com"
 
@@ -40,4 +46,6 @@ Versions: ["PATH"]
 -- x.cue --
 package x
 
-x: 5
+import "acme.com/other"
+
+x: other.y


### PR DESCRIPTION
Finding a cue.mod directory indicates we have found a module. Currently,
we continue to recurse into a cue.mod directory to find other modules.
However, this is not correct from the perspective of unity: any modules
we find within cue.mod/{gen,pkg,usr} will only ever be modules vendored
as dependencies of the module we have just found, which from unity's
perspective is not what we are after.

Therefore skip cue.mod directories themselves.

Fixes #59